### PR TITLE
feat: Add Zero-Code CLI and FastAPI REST Server (v1.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,26 @@ brew install libmagic poppler tesseract qpdf libreoffice pandoc
 
 ### 1. Zero-Code CLI & API Server (New in 1.1.0!)
 
-If you just want a REST API backed by LongTrainer:
+Manage bots, chat, and run a production API directly from your terminal—no Python required.
 
+#### A. Interactive Terminal Chat
 ```bash
-# 1. Initialize a new project
+# 1. Initialize a new project and generate longtrainer.yaml
 longtrainer init
 
-# (Follow the interactive prompts to select MongoDB, LLM, chunk sizes, etc.)
+# 2. Create a new bot
+longtrainer bot create --prompt "You are a helpful assistant."
 
-# 2. Start the API server
+# 3. Add a document (PDF, link, etc.)
+longtrainer add-doc <bot_id> /path/to/document.pdf
+
+# 4. Start chatting!
+longtrainer chat <bot_id>
+```
+
+#### B. FastAPI REST Server
+Start a production-ready API server backed by your LongTrainer bots:
+```bash
 longtrainer serve
 ```
 

--- a/cli-test.yaml
+++ b/cli-test.yaml
@@ -1,0 +1,13 @@
+mongo_endpoint: mongodb://localhost:27017/
+llm:
+  provider: openai
+  model_name: gpt-4o-mini
+embedding:
+  model_name: text-embedding-3-small
+chunking:
+  chunk_size: 1024
+  chunk_overlap: 100
+encrypt_chats: false
+server:
+  host: 0.0.0.0
+  port: 8000

--- a/docs/docs/cli_api.md
+++ b/docs/docs/cli_api.md
@@ -42,6 +42,41 @@ Options:
 - `-p, --port INTEGER`: Override the port.
 - `--reload`: Enable auto-reload for development.
 
+### Bot Management
+
+You can directly manage your MongoDB-backed bots from the terminal without starting a Python script.
+
+```bash
+# List all existing bots
+longtrainer bot list
+
+# Create a new, isolated bot
+longtrainer bot create --prompt "You are a helpful assistant."
+
+# Delete a bot and all its vector data/chat history
+longtrainer bot delete <bot_id>
+```
+
+### Document Ingestion
+
+Upload documents or scrape links directly into a bot database from the command line:
+
+```bash
+# Add a local PDF file
+longtrainer add-doc <bot_id> /path/to/document.pdf
+
+# Add a web URL
+longtrainer add-doc <bot_id> https://en.wikipedia.org/wiki/Python_(programming_language)
+```
+
+### Interactive Chat
+
+Start a secure, interactive ChatGPT-like terminal session with any bot. History is saved automatically.
+
+```bash
+longtrainer chat <bot_id>
+```
+
 ---
 
 ## 2. The REST API


### PR DESCRIPTION
This PR transforms LongTrainer from a Python library into a complete, language-agnostic service. 

### ✨ What's Included
* **Complete CLI ([cli.py](cci:7://file:///home/mudassir/PycharmProjects/Longtrainer/Long-Trainer/longtrainer/cli.py:0:0-0:0))**: Users can now scaffold projects (`longtrainer init`), manage bots (`bot create/list/delete`), ingest documents (`add-doc`), and chat interactively ([chat](cci:1://file:///home/mudassir/PycharmProjects/Longtrainer/Long-Trainer/longtrainer/api.py:243:0-272:59)) directly from the terminal.
* **FastAPI Server ([api.py](cci:7://file:///home/mudassir/PycharmProjects/Longtrainer/Long-Trainer/longtrainer/api.py:0:0-0:0))**: A production-ready REST API with 16 endpoints for full bot lifecycle management, sync/streaming chat, and vision support. Includes lazy initialization so the server starts instantly without requiring an API key. 
* **Documentation**: Updated [README.md](cci:7://file:///home/mudassir/PycharmProjects/Longtrainer/Long-Trainer/README.md:0:0-0:0) with CLI/API quick starts, updated [CHANGELOG.md](cci:7://file:///home/mudassir/PycharmProjects/Longtrainer/Long-Trainer/CHANGELOG.md:0:0-0:0), and added a new comprehensive MkDocs guide at [cli_api.md](cci:7://file:///home/mudassir/PycharmProjects/Longtrainer/Long-Trainer/docs/docs/cli_api.md:0:0-0:0).
* **CI Testing**: Added [test_05_cli.py](cci:7://file:///home/mudassir/PycharmProjects/Longtrainer/Long-Trainer/tests/test_05_cli.py:0:0-0:0) and [test_06_api.py](cci:7://file:///home/mudassir/PycharmProjects/Longtrainer/Long-Trainer/tests/test_06_api.py:0:0-0:0) (8 new tests). Updated [.github/workflows/ci.yml](cci:7://file:///home/mudassir/PycharmProjects/Longtrainer/Long-Trainer/.github/workflows/ci.yml:0:0-0:0) so all integrations are now automatically tested.
* **Version Bump**: Ready for release as `v1.1.0`.
